### PR TITLE
Update maven-version to 3.9.6 from 3.9.1

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,5 +1,5 @@
 # bump: maven-version /MAVEN_VERSION="(.*)"/ https://maven.apache.org/download.cgi|re:/Maven.([\d.]+).is.the.latest/$1/
-MAVEN_VERSION="3.9.1" # Specify a stable release
+MAVEN_VERSION="3.9.6" # Specify a stable release
 
 export MAVEN_MAJOR_VERSION=$(echo "$MAVEN_VERSION" | cut -d '.' -f 1)
 export ZOPEN_STABLE_TAG="v${MAVEN_VERSION}"

--- a/buildenv
+++ b/buildenv
@@ -49,6 +49,12 @@ zopen_maven_install()
   echo "here-at-maven_install $PWD"
   echo "here-at-maven_install $ZOPEN_INSTALL_DIR"
 
+  #Higher version of maven tool is supporting m2.conf file in UTF-8
+  /bin/iconv -f ISO8859-1 -t UTF8 "$PWD/bin/m2.conf" > "$PWD/bin/m2.conf.utf8"
+  /bin/chtag -tc 1208 "$PWD/bin/m2.conf.utf8"
+  cp "$PWD/bin/m2.conf.utf8" "$PWD/bin/m2.conf" 
+  rm "$PWD/bin/m2.conf.utf8"
+
   mkdir -p "$ZOPEN_INSTALL_DIR/bin" "$ZOPEN_INSTALL_DIR/lib" "$ZOPEN_INSTALL_DIR/conf" "$ZOPEN_INSTALL_DIR/boot"
   cp -r "$PWD/bin/" "$ZOPEN_INSTALL_DIR/bin/"
   cp -r "$PWD/lib/" "$ZOPEN_INSTALL_DIR/lib/"


### PR DESCRIPTION
While the m2.conf file in Maven <=3.9.1 is compatible with ISO8859-1 encoding and functions as intended without char encoding, Maven > 3.9.1 supports UTF-8 encoding for the m2.conf file. In order to convert it manually from ISO8859-1 to UTF-8.